### PR TITLE
Fix compilation with gcc/g++ versions 13 and 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ $(OBJ_VEHVIS_DIR)/%.o: $(SRC_VEHVIS_DIR)/%.cc
 
 $(OBJ_ASN1_DIR)/%.o: $(SRC_ASN1_DIR)/%.c
 	@ mkdir -p $(OBJ_ASN1_DIR)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -Wno-incompatible-pointer-types -c $< -o $@
 
 $(OBJ_ETSI_DIR)/%.o: $(SRC_ETSI_DIR)/%.c
 	@ mkdir -p $(OBJ_ETSI_DIR)

--- a/asn1/include/asn_system.h
+++ b/asn1/include/asn_system.h
@@ -8,6 +8,8 @@
 #ifndef	ASN_SYSTEM_H
 #define	ASN_SYSTEM_H
 
+#include <arpa/inet.h> /* For htonl() and ntohl() */
+
 #ifdef	HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/include/vehicleDataDef.h
+++ b/include/vehicleDataDef.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <vector>
 #include <shared_mutex>
+#include <string>
 
 #define vehicleDataVector_t(name) std::vector<ldmmap::vehicleData_t> name;
 


### PR DESCRIPTION
This commit should fix compilation under Ubuntu 24 LTS, that uses by default gcc and g++ 13.